### PR TITLE
backend: make storage load resilient when boxes.json is absent

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "ts-node-dev --respawn src/server.ts",
     "build": "tsc",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "test": "npm run build && node --test dist/**/*.test.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/__tests__/storage.test.ts
+++ b/backend/src/__tests__/storage.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { loadBoxes, saveBoxes } from '../storage';
+
+test('storage roundtrip: saveBoxes + loadBoxes', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxvista-storage-'));
+  const previousCwd = process.cwd();
+
+  try {
+    process.chdir(tmpDir);
+    const payload = [
+      { id: 1, name: 'Caja 1', description: 'Desc', objetos: [] },
+    ];
+
+    saveBoxes(payload);
+    const loaded = loadBoxes();
+
+    assert.deepEqual(loaded, payload);
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('loadBoxes returns empty list when file does not exist', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxvista-storage-empty-'));
+  const previousCwd = process.cwd();
+
+  try {
+    process.chdir(tmpDir);
+    assert.deepEqual(loadBoxes(), []);
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/backend/src/storage.ts
+++ b/backend/src/storage.ts
@@ -4,7 +4,14 @@ import { Caja } from './types';
 const DATA_FILE = './boxes.json';
 
 export function loadBoxes(): Caja[] {
-  return JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+  try {
+    return JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
 }
 
 export function saveBoxes(boxes: Caja[]): void {


### PR DESCRIPTION
## Summary
- add backend storage unit tests (roundtrip + missing file behavior)
- add npm test script for backend build+node:test flow
- make loadBoxes return [] when boxes.json is missing

## Why
Running backend in a fresh environment without boxes.json currently crashes on read. This keeps startup/read paths safe and deterministic.
