### PR TITLE
[backend] MVP auth endpoints + JWT middleware

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,15 +10,19 @@
       "license": "ISC",
       "dependencies": {
         "@types/express": "^4.17.23",
+        "bcryptjs": "^2.4.3",
         "body-parser": "^2.2.0",
         "cors": "^2.8.5",
         "express": "^4.21.2",
+        "jsonwebtoken": "^9.0.2",
         "sequelize": "^6.37.7",
         "sqlite3": "^5.0.2"
       },
       "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
         "@types/body-parser": "^1.19.6",
         "@types/cors": "^2.8.19",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.0.3",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.8.3",
@@ -154,6 +158,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -222,6 +233,17 @@
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -239,7 +261,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
       "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -490,6 +511,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -610,6 +637,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -941,6 +974,15 @@
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1767,10 +1809,95 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -3246,7 +3373,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,9 @@
     "cors": "^2.8.5",
     "express": "^4.21.2",
     "sequelize": "^6.37.7",
-    "sqlite3": "^5.0.2"
+    "sqlite3": "^5.0.2",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.6",
@@ -27,6 +29,8 @@
     "@types/node": "^24.0.3",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.8.3",
-    "zod": "^3.25.67"
+    "zod": "^3.25.67",
+    "@types/bcryptjs": "^2.4.6",
+    "@types/jsonwebtoken": "^9.0.10"
   }
 }

--- a/backend/src/__tests__/auth.test.ts
+++ b/backend/src/__tests__/auth.test.ts
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { AddressInfo } from 'node:net';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import { app, initDatabase } from '../app';
+import { sequelize } from '../db';
+
+let baseUrl = '';
+let server: ReturnType<typeof app.listen>;
+
+test.before(async () => {
+  await initDatabase(true);
+  server = app.listen(0);
+  const addr = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+test.after(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err?: Error) => (err ? reject(err) : resolve()));
+  });
+  await sequelize.close();
+});
+
+test('register + login returns a JWT token', async () => {
+  const email = 'auth.user@example.com';
+  const password = 'StrongPass123!';
+
+  const registerRes = await fetch(`${baseUrl}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+
+  assert.equal(registerRes.status, 201);
+  const registerBody = await registerRes.json() as { token?: string };
+  assert.ok(registerBody.token);
+
+  const loginRes = await fetch(`${baseUrl}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+
+  assert.equal(loginRes.status, 200);
+  const loginBody = await loginRes.json() as { token?: string };
+  assert.ok(loginBody.token);
+});
+
+test('protected write endpoint rejects missing token and accepts valid token', async () => {
+  const email = 'writer.user@example.com';
+  const password = 'AnotherStrongPass123!';
+
+  const registerRes = await fetch(`${baseUrl}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  const registerBody = await registerRes.json() as { token: string };
+
+  const unauthorizedCreate = await fetch(`${baseUrl}/api/boxes`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name: 'Caja protegida', description: 'Debe requerir token' }),
+  });
+  assert.equal(unauthorizedCreate.status, 401);
+
+  const authorizedCreate = await fetch(`${baseUrl}/api/boxes`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${registerBody.token}`,
+    },
+    body: JSON.stringify({ name: 'Caja protegida', description: 'Creada con token' }),
+  });
+
+  assert.equal(authorizedCreate.status, 201);
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,23 @@
+import express from 'express';
+import cors from 'cors';
+import bodyParser from 'body-parser';
+
+import { sequelize } from './db';
+import './models';
+
+import boxesRouter from './routes/boxes';
+import objectsRouter from './routes/objects';
+import authRouter from './routes/auth';
+
+export const app = express();
+
+app.use(cors());
+app.use(bodyParser.json());
+
+app.use('/api/auth', authRouter);
+app.use('/api/boxes', boxesRouter);
+app.use('/api/boxes/:boxId/objects', objectsRouter);
+
+export const initDatabase = async (force = false): Promise<void> => {
+  await sequelize.sync({ force });
+};

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,7 +1,9 @@
 import { Sequelize } from 'sequelize';
 
+const isTest = process.env.NODE_ENV === 'test';
+
 export const sequelize = new Sequelize({
   dialect: 'sqlite',
-  storage: './database.sqlite',
-  logging: true,       // quita o pon true si quieres ver cada query
+  storage: isTest ? ':memory:' : './database.sqlite',
+  logging: false,
 });

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,33 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+export interface AuthPayload {
+  userId: number;
+  email: string;
+}
+
+export interface AuthenticatedRequest extends Request {
+  auth?: AuthPayload;
+}
+
+const getJwtSecret = (): string => process.env.JWT_SECRET || 'boxvista-dev-secret';
+
+export const signAuthToken = (payload: AuthPayload): string => jwt.sign(payload, getJwtSecret(), { expiresIn: '7d' });
+
+export const requireAuth = (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Missing or invalid authorization header' });
+  }
+
+  const token = authHeader.slice('Bearer '.length).trim();
+
+  try {
+    const decoded = jwt.verify(token, getJwtSecret()) as AuthPayload;
+    req.auth = decoded;
+    return next();
+  } catch {
+    return res.status(401).json({ message: 'Invalid or expired token' });
+  }
+};

--- a/backend/src/models.ts
+++ b/backend/src/models.ts
@@ -55,8 +55,34 @@ ObjectItem.init({
   sequelize,
   tableName: 'objects',
   timestamps: false,
-  // Add index on boxId for faster lookups when fetching objects by box
   indexes: [{ fields: ['boxId'] }],
+});
+
+export class User extends Model {
+  public id!: number;
+  public email!: string;
+  public passwordHash!: string;
+}
+
+User.init({
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true,
+  },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    unique: true,
+  },
+  passwordHash: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+}, {
+  sequelize,
+  tableName: 'users',
+  timestamps: false,
 });
 
 // Relaciones

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,58 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import bcrypt from 'bcryptjs';
+
+import { User } from '../models';
+import { signAuthToken } from '../middleware/auth';
+
+const router = Router();
+
+const authSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+});
+
+router.post('/register', async (req, res) => {
+  const parsed = authSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({ message: 'Invalid payload', errors: parsed.error.issues });
+  }
+
+  const { email, password } = parsed.data;
+  const existing = await User.findOne({ where: { email: email.toLowerCase() } });
+  if (existing) {
+    return res.status(409).json({ message: 'Email already registered' });
+  }
+
+  const passwordHash = await bcrypt.hash(password, 10);
+  const user = await User.create({ email: email.toLowerCase(), passwordHash });
+
+  const token = signAuthToken({ userId: user.id, email: user.email });
+  return res.status(201).json({ token });
+});
+
+router.post('/login', async (req, res) => {
+  const parsed = authSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({ message: 'Invalid payload', errors: parsed.error.issues });
+  }
+
+  const { email, password } = parsed.data;
+  const user = await User.findOne({ where: { email: email.toLowerCase() } });
+
+  if (!user) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+
+  const valid = await bcrypt.compare(password, user.passwordHash);
+  if (!valid) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+
+  const token = signAuthToken({ userId: user.id, email: user.email });
+  return res.status(200).json({ token });
+});
+
+export default router;

--- a/backend/src/routes/boxes.ts
+++ b/backend/src/routes/boxes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { Box, ObjectItem } from '../models';
 import { validate } from '../middleware/validate';
+import { requireAuth } from '../middleware/auth';
 
 const router = Router();
 
@@ -36,7 +37,7 @@ router.get('/:boxId', async (req, res) => {
 });
 
 // POST create box + its objetos
-router.post('/', validate(boxSchema), async (req, res) => {
+router.post('/', requireAuth, validate(boxSchema), async (req, res) => {
   const { name, description, objetos = [] } = req.body;
   const newBox = await Box.create({ name, description });
 
@@ -56,7 +57,7 @@ router.post('/', validate(boxSchema), async (req, res) => {
 });
 
 // PUT update box (no update de objetos aquí)
-router.put('/:boxId', validate(boxSchema), async (req, res) => {
+router.put('/:boxId', requireAuth, validate(boxSchema), async (req, res) => {
   const box = await Box.findByPk(req.params.boxId);
   if (!box) return res.status(404).json({ message: 'Box not found' });
   await box.update(req.body);
@@ -64,7 +65,7 @@ router.put('/:boxId', validate(boxSchema), async (req, res) => {
 });
 
 // DELETE box (cascade elimina objetos)
-router.delete('/:boxId', async (req, res) => {
+router.delete('/:boxId', requireAuth, async (req, res) => {
   const box = await Box.findByPk(req.params.boxId);
   if (!box) return res.status(404).json({ message: 'Box not found' });
   await box.destroy();

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,31 +1,13 @@
-import express from 'express';
-import cors from 'cors';
-import bodyParser from 'body-parser';
+import { app, initDatabase } from './app';
 
-import { sequelize }   from './db';
-import './models';      // registra modelos con Sequelize
-
-import boxesRouter  from './routes/boxes';
-import objectsRouter from './routes/objects';
-import { loadBoxes } from './storage';
-
-const app = express();
 const PORT = process.env.PORT || 3000;
 
-app.use(cors());
-app.use(bodyParser.json());
-
-app.use('/api/boxes',               boxesRouter);
-app.use('/api/boxes/:boxId/objects', objectsRouter);
-
-// 🔥 En desarrollo: forza borrado y recreación de tablas
-sequelize.sync({ force: false }) // Cambia a `force: true` para borrar y recrear tablas
+initDatabase(false)
   .then(() => {
-    // loadBoxes(); // Carga cajas iniciales desde storage.ts
     app.listen(PORT, () => {
       console.log(`Servidor http://localhost:${PORT}`);
     });
   })
-  .catch(err => {
+  .catch((err) => {
     console.error('Error al sincronizar la base de datos:', err);
   });

--- a/docs/checklists/backend-checklist.md
+++ b/docs/checklists/backend-checklist.md
@@ -1,0 +1,45 @@
+# Backend Checklist (estado real vs objetivo)
+
+Fuente base: `tasks.md` + inspección de `backend/src/*`.
+Última revisión inicial: 2026-03-16.
+
+## Reglas para automatización (obligatorio)
+- Antes de implementar, leer este archivo completo.
+- Elegir **1 tarea pendiente** por ejecución (máximo 1 PR por run).
+- Al terminar, actualizar checks `[ ] -> [x]` y añadir evidencia breve (archivo/test/PR).
+- Si una tarea estaba marcada `[x]` pero está incompleta, revertir a `[ ]` y explicar por qué.
+- No editar secciones de Android/iOS.
+
+## Ya hecho (confirmado en código)
+- [x] API Express base operativa (`app.ts`, `server.ts`).
+- [x] Modelos de datos y relaciones base (`models.ts`).
+- [x] CRUD principal de cajas (`routes/boxes.ts`: list/get/create/update/delete).
+- [x] Verificación de contenido y conciliación (`POST /boxes/:id/verificar` + `services/conciliacion.ts`).
+- [x] Historial por caja (`GET /boxes/:id/historial`).
+- [x] Endpoint de visión interno para MVP (`routes/vision.ts` + `services/vision.ts`) con tests básicos.
+- [x] Suite de tests backend inicial (unit + rutas):
+  - `routes/__tests__/boxes.test.ts`
+  - `routes/__tests__/boxes.flow.e2e.test.ts`
+  - `routes/__tests__/vision.route.test.ts`
+  - `services/__tests__/*`
+
+## Pendiente priorizado (orden recomendado)
+- [x] Autenticación real para MVP (`/auth/register`, `/auth/login`, JWT middleware usable). ✅ 2026-03-17: implementado en `backend/src/routes/auth.ts` + `backend/src/middleware/auth.ts`, aplicado a escrituras en `routes/boxes.ts`; test `backend/src/__tests__/auth.test.ts` (register/login + protección con Bearer token).
+- [ ] Endpoint de actualización de ubicación alineado con requisitos (`PUT /cajas/{uuid}/ubicacion` o equivalente estable).
+- [ ] Paginación + filtros robustos en listado de cajas (estado/tipo/ubicación/fecha) con tests.
+- [ ] Contrato estable `cajas/*` (nombres y payloads) para paridad con apps móviles.
+- [ ] Subida multipart real de imágenes en verificación (actualmente flujo simplificado) con validación de tamaño/tipo.
+- [ ] Integración vision “real” (no mock) detrás de feature flag, **sin introducir runtime Python** (mantener stack Node/TypeScript).
+- [ ] Endpoint para guardar ajustes manuales tras verificación (actualizar relación caja-objeto + evento).
+- [ ] Endurecimiento de errores (códigos consistentes, trazabilidad, idempotencia de verificación).
+- [ ] Cobertura mínima objetivo: statements >= 80%, branches >= 70% en backend.
+- [ ] CI básica backend (lint + test) en GitHub Actions.
+
+## Bloqueadores / riesgos actuales
+- [ ] Inconsistencia de nomenclatura (`boxes` vs `cajas`) entre tareas y código.
+- [ ] `database.sqlite` versionado en repo (riesgo de conflictos y ruido en PRs).
+- [ ] `jest.config.js` vacío (riesgo de configuración implícita inestable).
+
+## Registro incremental de automatización
+- 2026-03-16: checklist inicial creada.
+- 2026-03-17: cerrada tarea de autenticación MVP con JWT (`/api/auth/register`, `/api/auth/login`) y middleware `requireAuth`; evidencia: `npm test` ✅ (incluye `src/__tests__/auth.test.ts`).


### PR DESCRIPTION
## Summary
- implement `/api/auth/register` and `/api/auth/login` with email/password validation and bcrypt hashing
- add reusable JWT middleware (`requireAuth`) and protect write operations on `/api/boxes` (POST/PUT/DELETE)
- refactor server bootstrapping to export app + DB init for testability
- add auth integration tests (register/login + unauthorized/authorized write flow)
- update backend checklist marking auth MVP task as completed with evidence

## Tests
- `cd backend && npm test`

## Checklist item closed
- Autenticación real para MVP (`/auth/register`, `/auth/login`, JWT middleware usable).
