### PR TITLE
Android: login backend real + token seguro

### DIFF
--- a/docs/checklists/android-checklist.md
+++ b/docs/checklists/android-checklist.md
@@ -1,0 +1,41 @@
+# Android Checklist (estado real vs objetivo)
+
+Fuente base: `tasks.md` + inspección de `mobile/BoxVista/*`.
+Última revisión inicial: 2026-03-16.
+
+## Reglas para automatización (obligatorio)
+- Antes de implementar, leer este archivo completo.
+- Trabajar **solo** en `mobile/BoxVista/`.
+- Elegir 1 tarea pendiente por ejecución.
+- Al cerrar una tarea: marcar `[x]` + añadir evidencia corta (archivo/test/PR).
+- Si detectas regresión, desmarcar `[x]` y documentar motivo.
+
+## Ya hecho (confirmado en código)
+- [x] Proyecto Android base con Kotlin + Compose (`MainActivity`, tema, estructura app).
+- [x] Home básico con listado de cajas/objetos (Compose) y modal de detalle.
+- [x] Capa de red inicial (`NetworkManager`, `services/BoxService`, `services/ObjectService`).
+- [x] Modelos principales (`models/Box.kt`, `models/ObjectItem.kt`).
+- [x] Tests iniciales unitarios + instrumentados presentes:
+  - `app/src/test/...`
+  - `app/src/androidTest/...`
+
+## Pendiente priorizado (orden recomendado)
+- [x] Login real contra backend (`POST /auth/login`) + almacenamiento seguro de token. _(2026-03-20: `NetworkManager.login`, `auth/SecureTokenStorage`, tests `NetworkManagerTest#testLogin` y `AuthRepositoryTest`)_
+- [ ] Crear caja desde UI (flujo completo con validaciones y manejo de errores).
+- [ ] Escaneo QR real (cámara + navegación a detalle por UUID).
+- [ ] Integración NFC/RFID básica (`NfcAdapter`) con fallback seguro.
+- [ ] Flujo de verificación con subida multipart de fotos (`/cajas/{uuid}/verificar`).
+- [ ] Pantalla/flujo de edición manual de discrepancias y guardado en backend.
+- [ ] Historial de caja en UI (`GET /cajas/{uuid}/historial`).
+- [ ] Manejo robusto de estados: loading/error/offline/retry en todos los flujos críticos.
+- [ ] Persistencia offline mínima (Room) para cajas/historial + sincronización diferida.
+- [ ] Cobertura de tests objetivo: unit + ui para casos de red caída, rotación y concurrencia.
+- [ ] CI Android básica (lint + test + connected test mínimo).
+
+## Bloqueadores / riesgos actuales
+- [ ] Divergencia de path en documentos (`mobile/android` histórico vs actual `mobile/BoxVista`).
+- [ ] Posible desalineación de contratos API backend/móvil (`boxes` vs `cajas`).
+- [ ] Necesidad de definir estrategia única de navegación y estado (evitar lógica dispersa).
+
+## Registro incremental de automatización
+- 2026-03-16: checklist inicial creada.

--- a/mobile/BoxVista/app/build.gradle.kts
+++ b/mobile/BoxVista/app/build.gradle.kts
@@ -73,5 +73,6 @@ dependencies {
     implementation("com.squareup.retrofit2:retrofit:3.0.0")
     implementation("com.squareup.retrofit2:converter-gson:3.0.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
+    implementation("androidx.security:security-crypto:1.1.0-alpha07")
 
 }

--- a/mobile/BoxVista/app/src/main/java/com/hirlu/boxvista/NetworkManager.kt
+++ b/mobile/BoxVista/app/src/main/java/com/hirlu/boxvista/NetworkManager.kt
@@ -2,6 +2,8 @@ package com.hirlu.boxvista
 
 import com.hirlu.boxvista.models.Box
 import com.hirlu.boxvista.models.BoxDTO
+import com.hirlu.boxvista.models.LoginRequest
+import com.hirlu.boxvista.models.LoginResponse
 import com.hirlu.boxvista.models.ObjectItem
 import com.hirlu.boxvista.models.ObjectItemDTO
 import retrofit2.Retrofit
@@ -29,6 +31,9 @@ object NetworkManager {
 
     // ───────────────────────────── API ─────────────────────────────
     private interface ApiService {
+        @POST("auth/login")
+        suspend fun login(@Body body: LoginRequest): LoginResponse
+
         @GET("boxes")
         suspend fun fetchBoxes(): List<BoxDTO>
 
@@ -90,6 +95,9 @@ object NetworkManager {
 
     // ──────────────────────── Métodos públicos suspend ─────────────────────────
     // Network exceptions (HttpException/IOException) propagate to the UI/VM layer for handling
+    suspend fun login(email: String, password: String): String =
+        requireApi().login(LoginRequest(email = email, password = password)).token
+
     suspend fun fetchBoxes(): List<Box> =
         requireApi().fetchBoxes().map { it.toDomain() }
 

--- a/mobile/BoxVista/app/src/main/java/com/hirlu/boxvista/auth/AuthRepository.kt
+++ b/mobile/BoxVista/app/src/main/java/com/hirlu/boxvista/auth/AuthRepository.kt
@@ -1,0 +1,20 @@
+package com.hirlu.boxvista.auth
+
+import com.hirlu.boxvista.NetworkManager
+
+class AuthRepository(
+    private val tokenStorage: TokenStorage,
+    private val loginCall: suspend (String, String) -> String = NetworkManager::login,
+) {
+    suspend fun login(email: String, password: String): String {
+        val token = loginCall(email, password)
+        tokenStorage.saveToken(token)
+        return token
+    }
+
+    fun getStoredToken(): String? = tokenStorage.getToken()
+
+    fun logout() {
+        tokenStorage.clearToken()
+    }
+}

--- a/mobile/BoxVista/app/src/main/java/com/hirlu/boxvista/auth/SecureTokenStorage.kt
+++ b/mobile/BoxVista/app/src/main/java/com/hirlu/boxvista/auth/SecureTokenStorage.kt
@@ -1,0 +1,40 @@
+package com.hirlu.boxvista.auth
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+interface TokenStorage {
+    fun saveToken(token: String)
+    fun getToken(): String?
+    fun clearToken()
+}
+
+class SecureTokenStorage(context: Context) : TokenStorage {
+    private val masterKey = MasterKey.Builder(context)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+
+    private val preferences = EncryptedSharedPreferences.create(
+        context,
+        FILE_NAME,
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+    )
+
+    override fun saveToken(token: String) {
+        preferences.edit().putString(KEY_TOKEN, token).apply()
+    }
+
+    override fun getToken(): String? = preferences.getString(KEY_TOKEN, null)
+
+    override fun clearToken() {
+        preferences.edit().remove(KEY_TOKEN).apply()
+    }
+
+    private companion object {
+        const val FILE_NAME = "boxvista_secure_session"
+        const val KEY_TOKEN = "auth_token"
+    }
+}

--- a/mobile/BoxVista/app/src/main/java/com/hirlu/boxvista/models/Auth.kt
+++ b/mobile/BoxVista/app/src/main/java/com/hirlu/boxvista/models/Auth.kt
@@ -1,0 +1,10 @@
+package com.hirlu.boxvista.models
+
+data class LoginRequest(
+    val email: String,
+    val password: String,
+)
+
+data class LoginResponse(
+    val token: String,
+)

--- a/mobile/BoxVista/app/src/main/java/com/hirlu/boxvista/views/homescreen/HomeScreenView.kt
+++ b/mobile/BoxVista/app/src/main/java/com/hirlu/boxvista/views/homescreen/HomeScreenView.kt
@@ -97,7 +97,7 @@ fun HomeScreenView(
                 // Listado de cajas
                 items(
                     items = state.boxes,
-                    key = { box -> box.id }
+                    key = { box -> box.id ?: "box-${box.name}" }
                 ) { box ->
                     HomeScreenBoxView(
                         box = box,
@@ -277,7 +277,7 @@ fun HomeScreenViewWithDataPreview() {
 
         items(
             items = boxes,
-            key = { box -> box.id }
+            key = { box -> box.id ?: "box-${box.name}" }
         ) { box ->
             HomeScreenBoxView(box)
         }

--- a/mobile/BoxVista/app/src/test/java/com/hirlu/boxvista/NetworkManagerTest.kt
+++ b/mobile/BoxVista/app/src/test/java/com/hirlu/boxvista/NetworkManagerTest.kt
@@ -7,6 +7,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -24,6 +25,22 @@ class NetworkManagerTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
+    }
+
+    @Test
+    fun testLogin() = runTest {
+        val mockResponse = MockResponse()
+            .setResponseCode(200)
+            .setBody("{\"token\":\"jwt-token-123\"}")
+        mockWebServer.enqueue(mockResponse)
+
+        val token = NetworkManager.login("test@example.com", "secret")
+        val request = mockWebServer.takeRequest()
+
+        assertEquals("jwt-token-123", token)
+        assertEquals("POST", request.method)
+        assertEquals("/auth/login", request.path)
+        assertTrue(request.body.readUtf8().contains("\"email\":\"test@example.com\""))
     }
 
     @Test

--- a/mobile/BoxVista/app/src/test/java/com/hirlu/boxvista/auth/AuthRepositoryTest.kt
+++ b/mobile/BoxVista/app/src/test/java/com/hirlu/boxvista/auth/AuthRepositoryTest.kt
@@ -1,0 +1,50 @@
+package com.hirlu.boxvista.auth
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AuthRepositoryTest {
+
+    @Test
+    fun `login stores returned token`() = runTest {
+        val storage = FakeTokenStorage()
+        val repository = AuthRepository(
+            tokenStorage = storage,
+            loginCall = { _, _ -> "jwt-token-123" },
+        )
+
+        val token = repository.login("test@example.com", "secret")
+
+        assertEquals("jwt-token-123", token)
+        assertEquals("jwt-token-123", repository.getStoredToken())
+    }
+
+    @Test
+    fun `logout clears token`() {
+        val storage = FakeTokenStorage(initialToken = "jwt-token-123")
+        val repository = AuthRepository(
+            tokenStorage = storage,
+            loginCall = { _, _ -> "ignored" },
+        )
+
+        repository.logout()
+
+        assertNull(repository.getStoredToken())
+    }
+
+    private class FakeTokenStorage(initialToken: String? = null) : TokenStorage {
+        private var token: String? = initialToken
+
+        override fun saveToken(token: String) {
+            this.token = token
+        }
+
+        override fun getToken(): String? = token
+
+        override fun clearToken() {
+            token = null
+        }
+    }
+}


### PR DESCRIPTION
## Resumen
- añade login real contra `POST /auth/login` en `NetworkManager`
- incorpora almacenamiento cifrado del token con `EncryptedSharedPreferences`
- agrega `AuthRepository` para persistir token tras login
- actualiza checklist Android con evidencia y fecha

## Tests
- `./gradlew :app:testDebugUnitTest -x checkDebugAarMetadata`

## Nota
- Se corrigió un error de compilación preexistente en `HomeScreenView` (`key` nullable) para permitir ejecutar los tests.