### PR TITLE
[backend] Endpoint PUT /api/cajas/:boxId/ubicacion + tests

### DIFF
--- a/backend/src/__tests__/auth.test.ts
+++ b/backend/src/__tests__/auth.test.ts
@@ -29,7 +29,7 @@ test('register + login returns a JWT token', async () => {
   const email = 'auth.user@example.com';
   const password = 'StrongPass123!';
 
-  const registerRes = await fetch(`${baseUrl}/api/auth/register`, {
+  const registerRes = await fetch(`${baseUrl}/auth/register`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ email, password }),
@@ -39,7 +39,7 @@ test('register + login returns a JWT token', async () => {
   const registerBody = await registerRes.json() as { token?: string };
   assert.ok(registerBody.token);
 
-  const loginRes = await fetch(`${baseUrl}/api/auth/login`, {
+  const loginRes = await fetch(`${baseUrl}/auth/login`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ email, password }),
@@ -48,6 +48,15 @@ test('register + login returns a JWT token', async () => {
   assert.equal(loginRes.status, 200);
   const loginBody = await loginRes.json() as { token?: string };
   assert.ok(loginBody.token);
+
+  // backwards compatibility for mobile clients already using /api/auth
+  const loginViaApiPrefix = await fetch(`${baseUrl}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+
+  assert.equal(loginViaApiPrefix.status, 200);
 });
 
 test('protected write endpoint rejects missing token and accepts valid token', async () => {

--- a/backend/src/__tests__/box-location.test.ts
+++ b/backend/src/__tests__/box-location.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { AddressInfo } from 'node:net';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import { app, initDatabase } from '../app';
+import { sequelize } from '../db';
+
+let baseUrl = '';
+let server: ReturnType<typeof app.listen>;
+
+test.before(async () => {
+  await initDatabase(true);
+  server = app.listen(0);
+  const addr = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+test.after(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err?: Error) => (err ? reject(err) : resolve()));
+  });
+  await sequelize.close();
+});
+
+test('PUT /api/cajas/:boxId/ubicacion actualiza ubicación de caja', async () => {
+  const authRes = await fetch(`${baseUrl}/auth/register`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'location.user@example.com', password: 'StrongPass123!' }),
+  });
+  const authBody = await authRes.json() as { token: string };
+
+  const createRes = await fetch(`${baseUrl}/api/boxes`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${authBody.token}`,
+    },
+    body: JSON.stringify({ name: 'Caja ubicación', description: 'inicial' }),
+  });
+  assert.equal(createRes.status, 201);
+
+  const created = await createRes.json() as { id: number };
+
+  const updateRes = await fetch(`${baseUrl}/api/cajas/${created.id}/ubicacion`, {
+    method: 'PUT',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${authBody.token}`,
+    },
+    body: JSON.stringify({ ubicacion: 'Estantería A-3' }),
+  });
+
+  assert.equal(updateRes.status, 200);
+  const updated = await updateRes.json() as { id: number; ubicacion: string };
+  assert.equal(updated.id, created.id);
+  assert.equal(updated.ubicacion, 'Estantería A-3');
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -14,9 +14,12 @@ export const app = express();
 app.use(cors());
 app.use(bodyParser.json());
 
+app.use('/auth', authRouter);
 app.use('/api/auth', authRouter);
 app.use('/api/boxes', boxesRouter);
+app.use('/api/cajas', boxesRouter);
 app.use('/api/boxes/:boxId/objects', objectsRouter);
+app.use('/api/cajas/:boxId/objetos', objectsRouter);
 
 export const initDatabase = async (force = false): Promise<void> => {
   await sequelize.sync({ force });

--- a/backend/src/models.ts
+++ b/backend/src/models.ts
@@ -6,6 +6,7 @@ export class Box extends Model {
   public id!: number;
   public name!: string;
   public description!: string;
+  public ubicacion?: string;
   public readonly objetos?: ObjectItem[];
 }
 Box.init({
@@ -19,6 +20,10 @@ Box.init({
   },
   description: {
     type: DataTypes.TEXT, allowNull: false
+  },
+  ubicacion: {
+    type: DataTypes.STRING,
+    allowNull: true,
   },
 }, {
   sequelize,

--- a/backend/src/routes/boxes.ts
+++ b/backend/src/routes/boxes.ts
@@ -23,6 +23,10 @@ const boxSchema = z.object({
   objetos:     z.array(objetoSchema).optional(),
 });
 
+const ubicacionSchema = z.object({
+  ubicacion: z.string().min(1),
+});
+
 // GET all boxes
 router.get('/', async (req, res) => {
   const list = await Box.findAll({ include: 'objetos' });
@@ -61,6 +65,14 @@ router.put('/:boxId', requireAuth, validate(boxSchema), async (req, res) => {
   const box = await Box.findByPk(req.params.boxId);
   if (!box) return res.status(404).json({ message: 'Box not found' });
   await box.update(req.body);
+  res.json(box);
+});
+
+router.put('/:boxId/ubicacion', requireAuth, validate(ubicacionSchema), async (req, res) => {
+  const box = await Box.findByPk(req.params.boxId);
+  if (!box) return res.status(404).json({ message: 'Box not found' });
+
+  await box.update({ ubicacion: req.body.ubicacion });
   res.json(box);
 });
 

--- a/docs/checklists/backend-checklist.md
+++ b/docs/checklists/backend-checklist.md
@@ -25,7 +25,7 @@ Fuente base: `tasks.md` + inspección de `backend/src/*`.
 
 ## Pendiente priorizado (orden recomendado)
 - [x] Autenticación real para MVP (`/auth/register`, `/auth/login`, JWT middleware usable). ✅ 2026-03-17: implementado en `backend/src/routes/auth.ts` + `backend/src/middleware/auth.ts`, aplicado a escrituras en `routes/boxes.ts`; test `backend/src/__tests__/auth.test.ts` (register/login + protección con Bearer token).
-- [ ] Endpoint de actualización de ubicación alineado con requisitos (`PUT /cajas/{uuid}/ubicacion` o equivalente estable).
+- [x] Endpoint de actualización de ubicación alineado con requisitos (`PUT /cajas/{uuid}/ubicacion` o equivalente estable). ✅ 2026-03-20: implementado `PUT /api/cajas/:boxId/ubicacion` (alias estable) en `backend/src/routes/boxes.ts`, con alias en `backend/src/app.ts` y persistencia de `ubicacion` en `backend/src/models.ts`; test de contrato `backend/src/__tests__/box-location.test.ts`.
 - [ ] Paginación + filtros robustos en listado de cajas (estado/tipo/ubicación/fecha) con tests.
 - [ ] Contrato estable `cajas/*` (nombres y payloads) para paridad con apps móviles.
 - [ ] Subida multipart real de imágenes en verificación (actualmente flujo simplificado) con validación de tamaño/tipo.


### PR DESCRIPTION
## Resumen
Cierra el ítem priorizado del checklist backend para actualización de ubicación de cajas.

## Cambios
- Añadido endpoint autenticado `PUT /api/cajas/:boxId/ubicacion` (alias estable) en `backend/src/routes/boxes.ts`.
- Añadido campo persistente `ubicacion` en modelo `Box` (`backend/src/models.ts`).
- Añadidos aliases en app para contrato en español:
  - `/api/cajas`
  - `/api/cajas/:boxId/objetos`
- Test TDD de contrato para ubicación en `backend/src/__tests__/box-location.test.ts`.
- Ajuste de test auth para validar `/auth/*` y compatibilidad `/api/auth/*` en `backend/src/__tests__/auth.test.ts`.
- Checklist actualizado en `docs/checklists/backend-checklist.md`.

## Validación
- `cd backend && NODE_ENV=test npm test` ✅

## Checklist cerrado
- [x] Endpoint de actualización de ubicación alineado con requisitos (`PUT /cajas/{uuid}/ubicacion` o equivalente estable).